### PR TITLE
closes #39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.6.0",
+        "@mui/material": "^5.6.1",
         "axios": "^0.24.0",
         "node-gyp": "^8.4.1",
         "node-sass": "^7.0.1",
@@ -2776,15 +2776,15 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-alpha.75",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.75.tgz",
-      "integrity": "sha512-eQ8SP2ML5nJyOdSqmk26ezg/eEP1k42Z+k6uMfNbgHZc8iZwgw9iVe+6g5j/qZPKS88AtxVG8YsLLZkXT82/Bw==",
+      "version": "5.0.0-alpha.76",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.76.tgz",
+      "integrity": "sha512-Pd0l4DvjXiGRyipn/CTDlYB2XrJwhpLktVXvbvcmzL2SMDaNprSarZqBkPHIubkulmRDZEEcnFDrpKgeSJDg4A==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@emotion/is-prop-valid": "^1.1.2",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
-        "@popperjs/core": "^2.11.4",
+        "@mui/utils": "^5.6.1",
+        "@popperjs/core": "^2.11.5",
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
@@ -2797,7 +2797,7 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       },
@@ -2808,15 +2808,15 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.6.0.tgz",
-      "integrity": "sha512-yh4FoRRPTgJWjv1oIu3YuvfYGD/WOEnyGizQ9fKs+hlMjIc0rzFpyUCo++P/3BUd0/hRKcI8D8mrpJK9OiOy1g==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.6.1.tgz",
+      "integrity": "sha512-xg6pPq+1jxWupwmPpnfmsHNjrsOe2xynUQWrRfcH8WHrrr1sQulq0VF4gORq/l8DD8a/jb4s8SsC20e/e6mHKQ==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
-        "@mui/base": "5.0.0-alpha.75",
-        "@mui/system": "^5.6.0",
+        "@mui/base": "5.0.0-alpha.76",
+        "@mui/system": "^5.6.1",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "@types/react-transition-group": "^4.4.4",
         "clsx": "^1.1.1",
         "csstype": "^3.0.11",
@@ -2835,7 +2835,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
       },
@@ -2852,12 +2852,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.6.0.tgz",
-      "integrity": "sha512-62jUFaMGfW3nvq/worcOAEiY++rWd44tpWShq4o97DybWmmWvEFYlBIuHEcXrtBIK/cloaQw8jqelQIFZeiVdw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.6.1.tgz",
+      "integrity": "sha512-8lgh+tUt/3ftStfvml3dwAzhW3fe/cUFjLcBViOTnWk7UixWR79me4qehsO4NVj0THpu3d2qclrLzdD8qBAWAQ==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "prop-types": "^15.7.2"
       },
       "engines": {
@@ -2868,7 +2868,7 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.6.0.tgz",
-      "integrity": "sha512-K1WPKTruJTPA49cub0HtDCBBvosPKizqgZ4RenAfWz/ldlFtM4p7e7Mt3YEnNWTOJMHvDGcEke1tCuELkVAMyA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.6.1.tgz",
+      "integrity": "sha512-jEhH6TBY8jc9S8yVncXmoTYTbATjEu44RMFXj6sIYfKr5NArVwTwRo3JexLL0t3BOAiYM4xsFLgfKEIvB9SAeQ==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@emotion/cache": "^11.7.1",
@@ -2908,15 +2908,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.6.0.tgz",
-      "integrity": "sha512-FoytH73hY78Dll6F0fg7AI/hnpplygbFeW0HsqBfwFWrt2PMc2YSq2ICqHzd2CZPIhzEgRHDTSI8bMTLtG9W7A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.6.1.tgz",
+      "integrity": "sha512-Y5pDvEOK6VOY+0vgNeyDuEEO5QCinhXbZQDyLOlaGLKuAoRGLXO9pcSsjZoGkewYZitXD44EDfgBQ+BqsAfgUA==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
-        "@mui/private-theming": "^5.6.0",
-        "@mui/styled-engine": "^5.6.0",
+        "@mui/private-theming": "^5.6.1",
+        "@mui/styled-engine": "^5.6.1",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "clsx": "^1.1.1",
         "csstype": "^3.0.11",
         "prop-types": "^15.7.2"
@@ -2931,7 +2931,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.6.0.tgz",
-      "integrity": "sha512-LbZKkCOn4243vbEVGbaKV7t6eN6kz7t95DR6AcUCRk4daH3l7CXPYkWsyzysRWdXgSzHmIyrgg4FZKzTy0dTHQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-CPrzrkiBusCZBLWu0Sg5MJvR3fKJyK3gKecLVX012LULyqg2U64Oz04BKhfkbtBrPBbSQxM+DWW9B1c9hmV9nQ==",
       "dependencies": {
         "@babel/runtime": "^7.17.2",
         "@types/prop-types": "^15.7.4",
@@ -20097,30 +20097,30 @@
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
     "@mui/base": {
-      "version": "5.0.0-alpha.75",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.75.tgz",
-      "integrity": "sha512-eQ8SP2ML5nJyOdSqmk26ezg/eEP1k42Z+k6uMfNbgHZc8iZwgw9iVe+6g5j/qZPKS88AtxVG8YsLLZkXT82/Bw==",
+      "version": "5.0.0-alpha.76",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.76.tgz",
+      "integrity": "sha512-Pd0l4DvjXiGRyipn/CTDlYB2XrJwhpLktVXvbvcmzL2SMDaNprSarZqBkPHIubkulmRDZEEcnFDrpKgeSJDg4A==",
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@emotion/is-prop-valid": "^1.1.2",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
-        "@popperjs/core": "^2.11.4",
+        "@mui/utils": "^5.6.1",
+        "@popperjs/core": "^2.11.5",
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
       }
     },
     "@mui/material": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.6.0.tgz",
-      "integrity": "sha512-yh4FoRRPTgJWjv1oIu3YuvfYGD/WOEnyGizQ9fKs+hlMjIc0rzFpyUCo++P/3BUd0/hRKcI8D8mrpJK9OiOy1g==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.6.1.tgz",
+      "integrity": "sha512-xg6pPq+1jxWupwmPpnfmsHNjrsOe2xynUQWrRfcH8WHrrr1sQulq0VF4gORq/l8DD8a/jb4s8SsC20e/e6mHKQ==",
       "requires": {
         "@babel/runtime": "^7.17.2",
-        "@mui/base": "5.0.0-alpha.75",
-        "@mui/system": "^5.6.0",
+        "@mui/base": "5.0.0-alpha.76",
+        "@mui/system": "^5.6.1",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "@types/react-transition-group": "^4.4.4",
         "clsx": "^1.1.1",
         "csstype": "^3.0.11",
@@ -20131,19 +20131,19 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.6.0.tgz",
-      "integrity": "sha512-62jUFaMGfW3nvq/worcOAEiY++rWd44tpWShq4o97DybWmmWvEFYlBIuHEcXrtBIK/cloaQw8jqelQIFZeiVdw==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.6.1.tgz",
+      "integrity": "sha512-8lgh+tUt/3ftStfvml3dwAzhW3fe/cUFjLcBViOTnWk7UixWR79me4qehsO4NVj0THpu3d2qclrLzdD8qBAWAQ==",
       "requires": {
         "@babel/runtime": "^7.17.2",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "prop-types": "^15.7.2"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.6.0.tgz",
-      "integrity": "sha512-K1WPKTruJTPA49cub0HtDCBBvosPKizqgZ4RenAfWz/ldlFtM4p7e7Mt3YEnNWTOJMHvDGcEke1tCuELkVAMyA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.6.1.tgz",
+      "integrity": "sha512-jEhH6TBY8jc9S8yVncXmoTYTbATjEu44RMFXj6sIYfKr5NArVwTwRo3JexLL0t3BOAiYM4xsFLgfKEIvB9SAeQ==",
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@emotion/cache": "^11.7.1",
@@ -20151,15 +20151,15 @@
       }
     },
     "@mui/system": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.6.0.tgz",
-      "integrity": "sha512-FoytH73hY78Dll6F0fg7AI/hnpplygbFeW0HsqBfwFWrt2PMc2YSq2ICqHzd2CZPIhzEgRHDTSI8bMTLtG9W7A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.6.1.tgz",
+      "integrity": "sha512-Y5pDvEOK6VOY+0vgNeyDuEEO5QCinhXbZQDyLOlaGLKuAoRGLXO9pcSsjZoGkewYZitXD44EDfgBQ+BqsAfgUA==",
       "requires": {
         "@babel/runtime": "^7.17.2",
-        "@mui/private-theming": "^5.6.0",
-        "@mui/styled-engine": "^5.6.0",
+        "@mui/private-theming": "^5.6.1",
+        "@mui/styled-engine": "^5.6.1",
         "@mui/types": "^7.1.3",
-        "@mui/utils": "^5.6.0",
+        "@mui/utils": "^5.6.1",
         "clsx": "^1.1.1",
         "csstype": "^3.0.11",
         "prop-types": "^15.7.2"
@@ -20172,9 +20172,9 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.6.0.tgz",
-      "integrity": "sha512-LbZKkCOn4243vbEVGbaKV7t6eN6kz7t95DR6AcUCRk4daH3l7CXPYkWsyzysRWdXgSzHmIyrgg4FZKzTy0dTHQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-CPrzrkiBusCZBLWu0Sg5MJvR3fKJyK3gKecLVX012LULyqg2U64Oz04BKhfkbtBrPBbSQxM+DWW9B1c9hmV9nQ==",
       "requires": {
         "@babel/runtime": "^7.17.2",
         "@types/prop-types": "^15.7.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
-    "@mui/material": "^5.6.0",
+    "@mui/material": "^5.6.1",
     "axios": "^0.24.0",
     "node-gyp": "^8.4.1",
     "node-sass": "^7.0.1",

--- a/src/components/routing/routers/AppRouter.js
+++ b/src/components/routing/routers/AppRouter.js
@@ -5,6 +5,7 @@ import CreateLobby from "components/views/CreateLobby";
 import HomePage from "components/views/HomePage";
 import PublicLobbies from "components/views/PublicLobbies";
 import GameRouter from "./GameRouter";
+import LobbyByCode from "components/views/LobbyByCode";
 
 const AppRouter = () => {
     return (
@@ -27,6 +28,10 @@ const AppRouter = () => {
                 </Route>
                 <Route path="/game">
                     <GameRouter base="/game" />
+                </Route>
+                
+                <Route path="/join-lobby">
+                    <LobbyByCode />
                 </Route>
             </Switch>
         </BrowserRouter>

--- a/src/components/routing/routers/LobbyRouter.js
+++ b/src/components/routing/routers/LobbyRouter.js
@@ -5,7 +5,6 @@ import UpdateLobby from "components/views/lobby/UpdateLobby";
 import ShareQRCode from "components/views/lobby/ShareQRCode";
 import ShareLobbyCode from "components/views/lobby/ShareLobbyCode";
 import ScanQRCode from "components/views/ScanQRCode";
-import LobbyByCode from "components/views/LobbyByCode";
 
 const LobbyRouter = props => {
     /**
@@ -41,10 +40,6 @@ const LobbyRouter = props => {
                     </Route>
                     <Route path={`${props.base}/scan/qr`} render={() => {
                         return <ScanQRCode/>
-                    }} >
-                    </Route>
-                    <Route path={`/join-lobby`} render={() => {
-                        return <LobbyByCode />
                     }} >
                     </Route>
                 </Switch>

--- a/src/components/views/PublicLobbies.js
+++ b/src/components/views/PublicLobbies.js
@@ -26,7 +26,6 @@ const PublicLobbies = () => {
         history.push('/home');
     }
 
-    // TODO - UPDATE WITH JOIN BY CODE PAGE
     const joinLobbyByCode = () => {
         history.push('/join-lobby');
     }
@@ -35,7 +34,7 @@ const PublicLobbies = () => {
         async function fetchData() {
             try {
                 // TODO: Switch as soon as implemented
-                //const response = await api.get('/v1/game/lobby/1');
+                //const response = await api.get('/v1/game/lobby');
                 const response = jsonDataLobbies;
 
                 setLobbyData(response);
@@ -50,6 +49,7 @@ const PublicLobbies = () => {
 
     async function joinLobbyWithId(id) {
         try {
+            
             setJoining(true);
 
             //**TODO** here we need to call to the backend to join the lobby and set the token (unregistered User)
@@ -85,6 +85,7 @@ const PublicLobbies = () => {
                 },
                 "token": "THIS IS MY TOKEN"
             };
+        
 
             // Get the returned user and update a new object.
             const user = new UserModel(response.data);

--- a/src/components/views/lobby/jsonDataLobbies.js
+++ b/src/components/views/lobby/jsonDataLobbies.js
@@ -21,7 +21,7 @@ const jsonDataLobbies = [
       "visibility": "Lobby-1",
       "gameMode": "TWO_VS_TWO",
       "gameType": "UNRANKED",
-      "invitationCode": "FakeInvitationCode0"
+      "invitationCode": "FakeCode00"
   },
   {
    "id": 2,
@@ -38,7 +38,7 @@ const jsonDataLobbies = [
    "visibility": "PUBLIC",
    "gameMode": "ONE_VS_ONE",
    "gameType": "UNRANKED",
-   "invitationCode": "FakeInvitationCode1"
+   "invitationCode": "FakeCode01"
 },
      {
       "id": 3,
@@ -55,7 +55,7 @@ const jsonDataLobbies = [
       "visibility": "PUBLIC",
       "gameMode": "ONE_VS_ONE",
       "gameType": "UNRANKED",
-      "invitationCode": "FakeInvitationCode2"
+      "invitationCode": "FakeCode02"
   }
 ];
 


### PR DESCRIPTION
LobbyByCode updated to reflect the main theme (pop-ups)
Uses JsonLobbyData instead of the api call
matching of the code to ID is not implemented and needs to be connected with the server actions when those are implemented - to discuss on Thursday
code length changed to 10, like on server
jsonlobbydata invite codes changed to FakeCode00 etc. to be 10 digits as needed
join-lobby moved from LobbyRouter to AppRouter as "lobby/" not part of the URL - maybe we can discuss on Thursday if our naming is consistent? because if it should be lobby/scan/code, it might make sense for public-lobbies to be called "lobby" also
